### PR TITLE
Add README.md files for main kernel directories

### DIFF
--- a/arch/README.md
+++ b/arch/README.md
@@ -1,0 +1,42 @@
+# arch Directory
+
+This directory contains architecture-specific code for the Linux kernel. Each subdirectory within `arch/` is dedicated to a particular processor architecture (e.g., `x86`, `arm64`, `riscv`).
+
+## Purpose
+
+The primary purpose of the `arch/` directory is to abstract and manage the hardware differences between various CPU architectures, allowing the majority of the kernel code to remain architecture-independent. It provides the necessary interface between the generic kernel and the specific hardware it's running on.
+
+## Contents
+
+Within each architecture-specific subdirectory (e.g., `arch/x86/`), you will typically find:
+
+*   **`boot/`**: Code related to the boot process for that architecture, including bootloaders, decompression routines, and setup code.
+*   **`configs/`**: Default kernel configuration files (`defconfig`) for different platforms or variants of the architecture.
+*   **`include/asm/`**: Architecture-specific header files that define low-level details such as memory layout, register access, system call conventions, and interrupt handling.
+*   **`include/uapi/asm/`**: Header files that define the userspace API for this architecture.
+*   **`kernel/`**: Core architecture-specific kernel code. This includes:
+    *   Interrupt handling routines.
+    *   Signal handling.
+    *   Process management specifics (context switching, thread creation).
+    *   System call implementation details.
+    *   Timekeeping and timer implementations.
+    *   CPU-specific features and errata workarounds.
+    *   Power management and CPU idling.
+*   **`kvm/`**: Kernel-based Virtual Machine (KVM) support specific to the architecture, enabling hardware-assisted virtualization.
+*   **`lib/`**: Architecture-specific library functions, often optimized assembly routines for common operations like memory copying, checksums, etc.
+*   **`mm/`**: Memory management code specific to the architecture, including page table management, TLB (Translation Lookaside Buffer) handling, and memory initialization.
+*   **`pci/`**: PCI (Peripheral Component Interconnect) bus support tailored for the architecture.
+*   **Platform-specific directories**: Many architectures will have subdirectories for specific SoCs (System on a Chip), platforms, or machine types (e.g., `arch/arm/mach-omap2/` for TI OMAP2 processors). These contain code to support the unique hardware features of those platforms.
+
+## Use for Linux OS
+
+The code within the `arch/` directory is fundamental to making Linux portable across a vast range of hardware. It handles the low-level details that differ from one CPU to another, such as:
+
+*   **Bootstrapping the kernel**: Initializing the CPU, memory, and essential hardware.
+*   **Memory Management**: Setting up and managing page tables, handling memory addressing specifics.
+*   **Interrupts and Exceptions**: Configuring interrupt controllers and handling hardware exceptions and software interrupts.
+*   **System Calls**: Providing the bridge between user-space applications and kernel-space services.
+*   **Performance Optimizations**: Implementing architecture-specific optimized routines for critical kernel functions.
+*   **Hardware Abstraction**: Exposing a consistent interface to the rest of the kernel, hiding the complexities of the underlying hardware.
+
+Without the `arch/` directory, a separate version of the Linux kernel would be needed for each CPU architecture. This directory is a cornerstone of Linux's portability and wide hardware support.

--- a/drivers/README.md
+++ b/drivers/README.md
@@ -1,0 +1,63 @@
+# drivers Directory
+
+This directory houses the source code for all device drivers in the Linux kernel. Device drivers are essential pieces of software that allow the kernel to interact with and control hardware components.
+
+## Purpose
+
+The primary purpose of the `drivers/` directory is to provide a modular and organized way to manage the vast array of hardware that Linux supports. Each subdirectory typically corresponds to a class of devices (e.g., `net/` for network devices, `gpu/` for graphics processing units, `usb/` for Universal Serial Bus devices).
+
+## Contents
+
+The `drivers/` directory is one of the largest and most diverse in the kernel tree. Its structure is generally based on the type of hardware the drivers support. Common subdirectories include:
+
+*   **`acpi/`**: Drivers related to ACPI (Advanced Configuration and Power Interface), which is used for hardware discovery, configuration, power management, and other OS-level functions.
+*   **`ata/`**: Drivers for ATA (Advanced Technology Attachment) host controllers, which are used for connecting storage devices like hard drives and SSDs.
+*   **`block/`**: Drivers for block devices, which are storage devices that read and write data in fixed-size blocks (e.g., hard drives, SSDs, floppy disks).
+*   **`bluetooth/`**: Drivers for Bluetooth controllers and devices.
+*   **`char/`**: Drivers for character devices, which handle data as a stream of characters. This includes devices like serial ports, TTYs (teletypewriters), and random number generators.
+*   **`clk/`**: Drivers for clock controllers, which manage the clock signals required by various hardware components.
+*   **`dma/`**: Drivers for DMA (Direct Memory Access) controllers, which allow hardware to access system memory directly without CPU intervention.
+*   **`firmware/`**: Code related to loading and managing firmware for various devices.
+*   **`gpio/`**: Drivers for GPIO (General Purpose Input/Output) controllers, which allow software to control and read the state of digital pins.
+*   **`gpu/`**: Drivers for Graphics Processing Units (GPUs), primarily under the `drm/` (Direct Rendering Manager) subdirectory.
+*   **`hid/`**: Drivers for Human Interface Devices (HID) such as keyboards, mice, joysticks, and touchscreens.
+*   **`hwmon/`**: Drivers for hardware monitoring devices, which provide information about system temperature, voltage, fan speeds, etc.
+*   **`i2c/`**: Drivers for I2C (Inter-Integrated Circuit) bus adapters and devices.
+*   **`iio/`**: Drivers for Industrial I/O (IIO) devices, which include sensors like accelerometers, gyroscopes, magnetometers, and ADCs/DACs.
+*   **`input/`**: Drivers for input devices, including keyboards, mice, touchpads, and joysticks.
+*   **`irqchip/`**: Drivers for interrupt controllers.
+*   **`md/`**: Drivers for Multiple Devices (MD), such as software RAID.
+*   **`media/`**: Drivers for multimedia devices, including webcams, TV tuners, video capture cards, and radio receivers.
+*   **`misc/`**: Miscellaneous drivers that don't fit neatly into other categories.
+*   **`mmc/`**: Drivers for MMC (MultiMediaCard), SD (Secure Digital), and SDIO (Secure Digital Input/Output) host controllers and cards.
+*   **`mtd/`**: Drivers for Memory Technology Devices (MTD), which are typically flash memory devices (e.g., NOR and NAND flash).
+*   **`net/`**: Drivers for network interface controllers (NICs), including Ethernet, Wi-Fi, Bluetooth networking, and various other network protocols. This is one of the largest subdirectories.
+*   **`nfc/`**: Drivers for Near Field Communication (NFC) controllers.
+*   **`pci/`**: Drivers and support code for the PCI (Peripheral Component Interconnect) and PCIe (PCI Express) bus.
+*   **`pinctrl/`**: Drivers for pin controllers (pinmux), which manage the multiplexing and configuration of hardware pins.
+*   **`platform/`**: Drivers for platform-specific devices, often found on embedded systems or SoCs (System on a Chip).
+*   **`power/`**: Drivers related to power management, such as battery drivers and power supply monitors.
+*   **`pwm/`**: Drivers for Pulse Width Modulation (PWM) controllers.
+*   **`regulator/`**: Drivers for voltage and current regulators.
+*   **`reset/`**: Drivers for reset controllers.
+*   **`rtc/`**: Drivers for Real-Time Clocks (RTCs).
+*   **`scsi/`**: Drivers for SCSI (Small Computer System Interface) host adapters and devices.
+*   **`spi/`**: Drivers for SPI (Serial Peripheral Interface) bus controllers and devices.
+*   **`thermal/`**: Drivers for thermal management, including temperature sensors and cooling devices.
+*   **`tty/`**: Drivers and infrastructure for Teletypewriters (TTYs), including serial ports and virtual consoles.
+*   **`usb/`**: Drivers for USB (Universal Serial Bus) host controllers, hubs, and devices. This is another very large subdirectory.
+*   **`video/`**: Drivers for framebuffers and console display. Note that most GPU drivers are in `gpu/drm/`.
+*   **`watchdog/`**: Drivers for watchdog timers, which are hardware timers used to detect and recover from system hangs.
+
+## Use for Linux OS
+
+The `drivers/` directory is critical for the Linux kernel's ability to function on a wide variety of hardware. Its main roles include:
+
+*   **Hardware Interaction**: Providing the low-level code necessary to communicate with specific hardware components.
+*   **Abstraction**: Presenting a standardized interface to the rest of the kernel for different types of devices (e.g., all network cards use the netdev interface, all block devices use the block layer interface). This allows the core kernel to be hardware-agnostic.
+*   **Modularity**: Allowing drivers to be compiled as loadable kernel modules (`.ko` files). This means that only the drivers needed for the currently connected hardware need to be loaded into memory, saving resources. It also allows for third-party drivers to be added without recompiling the entire kernel.
+*   **Hardware Discovery and Initialization**: Detecting, initializing, and configuring hardware devices during system boot or when they are hot-plugged.
+*   **Power Management**: Implementing power-saving features for specific devices.
+*   **Error Handling**: Managing and reporting errors from hardware devices.
+
+Without the extensive collection of drivers in this directory, Linux would not be able to support the vast ecosystem of hardware it currently runs on. Contributions to this directory are a major part of kernel development, enabling support for new and existing hardware.

--- a/fs/README.md
+++ b/fs/README.md
@@ -1,0 +1,73 @@
+# fs Directory
+
+The `fs/` directory in the Linux kernel source tree contains the code for the Virtual File System (VFS), also known as the Virtual Filesystem Switch, and the implementations of various concrete file systems.
+
+## Purpose
+
+The primary purposes of the `fs/` directory are:
+
+1.  **Provide a unified interface for file operations**: The VFS layer allows user-space applications and other parts of the kernel to interact with different file systems using a common set of system calls (e.g., `open()`, `read()`, `write()`, `close()`, `mkdir()`).
+2.  **Manage and abstract different file system types**: It provides the infrastructure for registering and managing various file system implementations (e.g., ext4, XFS, Btrfs, NFS, FAT).
+3.  **Handle file system-related data structures**: It manages core kernel objects like inodes (index nodes), dentries (directory entries), superblocks, and file objects.
+
+## Contents
+
+The `fs/` directory is structured to separate the generic VFS layer from specific file system implementations. Key components include:
+
+*   **Core VFS files (directly in `fs/`)**:
+    *   `dcache.c`: Directory entry cache (dcache) management. Dentries represent path components and speed up pathname lookups.
+    *   `inode.c`: Inode management. Inodes store metadata about files (permissions, ownership, size, pointers to data blocks, etc.).
+    *   `super.c`: Superblock management. Superblocks store metadata about an entire file system instance.
+    *   `file.c`: File object management. File objects represent open files by processes.
+    *   `open.c`: Code for handling the `open()` system call and path lookups.
+    *   `read_write.c`: Implementation of `read()`, `write()`, `lseek()`, and related system calls.
+    *   `select.c`, `poll.c`, `eventpoll.c` (epoll): Support for I/O multiplexing.
+    *   `namespace.c`: Mount point and namespace management.
+    *   `exec.c`: Code for executing programs, including loading different binary formats (see also `fs/binfmt_*.c`).
+    *   `pipe.c`, `fifo.c`: Implementation of pipes and FIFOs (named pipes).
+    *   `namei.c`: Pathname lookup and resolution.
+    *   `stat.c`, `utimes.c`: Handling file status and timestamp updates.
+    *   `locks.c`: File locking mechanisms (flock, POSIX locks).
+    *   `xattr.c`: Extended attribute support.
+    *   `sync.c`: File system synchronization (`sync()`, `fsync()`, etc.).
+    *   `notify/`: Subdirectory for file system notification mechanisms like `inotify` and `fanotify`.
+    *   `binfmt_*.c`: Files for different binary format handlers (e.g., `binfmt_elf.c` for ELF executables, `binfmt_script.c` for scripts).
+
+*   **File system implementation subdirectories**: Each subdirectory typically represents a specific file system type. Examples:
+    *   `ext4/`: The Fourth Extended Filesystem.
+    *   `xfs/`: The XFS filesystem.
+    *   `btrfs/`: The Btrfs filesystem.
+    *   `nfs/`: The Network File System (client-side).
+    *   `nfsd/`: The Network File System (server-side).
+    *   `cifs/`: The Common Internet File System (for SMB/CIFS shares).
+    *   `fat/`: File Allocation Table filesystems (FAT12/16/32, VFAT).
+    *   `isofs/`: ISO 9660 filesystem for CD-ROMs.
+    *   `proc/`: The `/proc` pseudo-filesystem, providing an interface to kernel data structures.
+    *   `sysfs/`: The `/sys` pseudo-filesystem, exporting kernel object information.
+    *   `tmpfs/`: A memory-based filesystem.
+    *   `fuse/`: Filesystem in Userspace support.
+    *   `overlayfs/`: An overlay filesystem that merges multiple underlying filesystems.
+    *   And many others.
+
+*   **Other important files/subdirectories**:
+    *   `aio.c`: Asynchronous I/O support.
+    *   `buffer.c`: Buffer cache management (though modern Linux relies more on the page cache).
+    *   `cachefiles/`: Backend for caching network filesystems locally.
+    *   `fscache/`: Generic filesystem caching infrastructure.
+    *   `quota/`: Filesystem quota management.
+    *   `crypto/`: Filesystem-level encryption (fscrypt).
+    *   `verity/`: Filesystem-level integrity protection (fsverity).
+    *   `io_uring/`: High-performance asynchronous I/O interface.
+
+## Use for Linux OS
+
+The `fs/` directory is fundamental to how Linux manages data and interacts with storage and other data sources. Its key roles are:
+
+*   **Data Storage and Retrieval**: Providing the mechanisms to store, organize, and retrieve data on various storage media.
+*   **Hierarchical Namespace**: Implementing the familiar tree-like directory structure.
+*   **Access Control**: Enforcing permissions and access rights for files and directories.
+*   **Abstraction**: Allowing applications to work with files without needing to know the specifics of the underlying storage device or file system format.
+*   **Special Filesystems**: Providing interfaces to kernel internals and device drivers through pseudo-filesystems like `/proc` and `/sys`.
+*   **Networking Filesystems**: Enabling access to files stored on remote servers (e.g., NFS, CIFS).
+
+The VFS layer within `fs/` is a critical abstraction that makes Linux highly flexible and capable of supporting a diverse range of storage technologies and data organization schemes. It's a core component that underpins much of the system's functionality.

--- a/include/README.md
+++ b/include/README.md
@@ -1,0 +1,71 @@
+# include Directory
+
+The `include/` directory at the root of the Linux kernel source tree is a crucial part of the kernel's build system and internal structure. It contains header files that are used throughout the kernel.
+
+## Purpose
+
+The primary purposes of the `include/` directory are:
+
+1.  **Provide Kernel-Internal APIs and Definitions**: It houses header files that define data structures, macros, function prototypes, and constants used by various kernel subsystems. These are generally not meant for direct use by user-space applications.
+2.  **Expose User-Space APIs (UAPI)**: A specific subdirectory, `include/uapi/`, contains header files that define the Application Programming Interface (API) that the kernel presents to user-space programs. These are the headers that get installed on a system for developers to compile applications against (e.g., in `/usr/include/linux/`).
+3.  **Facilitate Modularity and Compilation**: Header files allow different parts of the kernel to share definitions and interfaces, enabling the compilation of individual kernel modules and subsystems.
+4.  **Architecture-Specific Definitions**: While this top-level `include/` directory contains generic headers, architecture-specific headers are found in `arch/<architecture>/include/`.
+
+## Contents
+
+The `include/` directory is organized into several subdirectories and also contains some top-level header files. Key components include:
+
+*   **`linux/`**: This is the largest and most important subdirectory. It contains a vast number of header files related to core kernel subsystems and features. Examples:
+    *   `fs.h`: Core VFS (Virtual File System) structures and definitions.
+    *   `sched.h`: Scheduler and task (process/thread) related structures.
+    *   `mm.h`: Memory management structures and functions.
+    *   `netdevice.h`: Network device interface.
+    *   `skbuff.h`: Socket buffer (network packet) manipulation.
+    *   `module.h`: Kernel module infrastructure.
+    *   `pci.h`: PCI bus interface.
+    *   `usb.h`: USB interface.
+    *   `types.h`: Basic kernel data types.
+    *   `kernel.h`: General kernel utility functions and macros.
+    *   `list.h`: Kernel's linked list implementation.
+    *   Many, many more, covering almost every aspect of the kernel.
+
+*   **`uapi/` (User API)**: This subdirectory contains headers that define the interface between the kernel and user-space applications.
+    *   **`linux/` (within `uapi/`)**: Headers for standard Linux system calls and structures (e.g., `uapi/linux/ioctl.h`, `uapi/linux/input.h`, `uapi/linux/socket.h`). These are the files typically installed into system include directories.
+    *   **`asm-generic/` (within `uapi/`)**: Generic UAPI headers that can be shared across architectures.
+    *   Architecture-specific UAPI headers (e.g., `uapi/asm-x86/`, `uapi/asm-arm/`) are symbolic links or copies managed by the build system, pointing to the actual files in `arch/<architecture>/include/uapi/asm/`.
+
+*   **`asm-generic/`**: Generic header files that provide default implementations or common definitions for functionalities that might otherwise be architecture-specific. Architectures can choose to use these or provide their own versions. Examples:
+    *   `io.h`: Generic I/O port access.
+    *   `mman.h`: Generic memory mapping definitions.
+    *   `signal.h`: Generic signal definitions.
+
+*   **`acpi/`**: Headers related to ACPI (Advanced Configuration and Power Interface).
+*   **`clocksource/`**: Headers for clock source management.
+*   **`crypto/`**: Headers for the kernel's cryptographic API.
+*   **`drm/`**: Headers for the Direct Rendering Manager (graphics).
+*   **`keys/`**: Kernel key management facility headers.
+*   **`media/`**: Headers for media device support (V4L2, DVB, etc.).
+*   **`net/`**: Extensive set of headers for networking protocols and subsystems.
+*   **`rdma/`**: Headers for Remote Direct Memory Access.
+*   **`scsi/`**: Headers for the SCSI subsystem.
+*   **`sound/`**: Headers for the ALSA (Advanced Linux Sound Architecture) and other sound subsystems.
+*   **`target/`**: Headers for SCSI target mode drivers (e.g., iSCSI target).
+*   **`trace/`**: Headers for kernel tracing facilities (ftrace, tracepoints, perf events).
+*   **`video/`**: Headers related to video framebuffers and display.
+*   **`xen/`**: Headers for Xen virtualization support.
+
+*   **Top-level headers**: Some important headers reside directly in `include/`, such as:
+    *   `Kbuild`: Used by the kbuild system.
+    *   `asm-generic-yguard.h`, `linux-yguard.h`, `uapi-yguard.h`: Header inclusion guards to prevent accidental direct inclusion of internal headers.
+
+## Use for Linux OS
+
+The `include/` directory is essential for both kernel development and user-space application development:
+
+*   **Kernel Compilation**: Provides the necessary definitions and declarations for compiling the kernel itself and its modules.
+*   **Kernel Development**: Serves as the primary reference for kernel-internal data structures, functions, and macros.
+*   **User-Space Development**: The `include/uapi/` subdirectory defines the stable API that user-space programs use to interact with the kernel via system calls and ioctls. These headers are distributed with C libraries (like glibc) and development packages.
+*   **Hardware Abstraction**: Together with `arch/<architecture>/include/`, it helps in abstracting hardware differences.
+*   **Interface Definition**: Defines the contracts between different kernel subsystems.
+
+It's a central repository of type definitions, constants, macros, and function prototypes that glue the entire kernel together and define its public-facing interface. The separation between internal kernel headers and UAPI headers is critical for maintaining a stable ABI (Application Binary Interface) for user-space while allowing the kernel internals to evolve.

--- a/init/README.md
+++ b/init/README.md
@@ -1,0 +1,59 @@
+# init Directory
+
+The `init/` directory in the Linux kernel source tree contains the core code responsible for the kernel's initialization process. This is where the kernel starts its journey after the architecture-specific bootloader has handed over control.
+
+## Purpose
+
+The primary purpose of the `init/` directory is to:
+
+1.  **Perform early kernel initialization**: Set up fundamental kernel data structures and subsystems.
+2.  **Calibrate system parameters**: Determine system properties like CPU speed.
+3.  **Initialize schedulers and timers**: Get the process scheduler and timing mechanisms operational.
+4.  **Mount the root filesystem**: Find and mount the root filesystem, which is crucial for further system startup.
+5.  **Start the `init` process**: Execute the first user-space process (usually `/sbin/init` or a similar program like `systemd`), which then takes over the rest of the system boot process.
+
+## Contents
+
+The `init/` directory contains a relatively small but critical set of files:
+
+*   **`main.c`**: This is the heart of the kernel's generic initialization sequence. It contains the `start_kernel()` function, which is the main entry point for architecture-independent kernel initialization. `start_kernel()` is responsible for:
+    *   Setting up memory management (calling `setup_arch()` which is architecture-specific).
+    *   Initializing trap handlers and interrupt vectors.
+    *   Initializing the scheduler (`sched_init()`).
+    *   Initializing timers and timekeeping.
+    *   Calibrating delays (`calibrate_delay()`).
+    *   Initializing various core kernel subsystems (VFS, buffer cache, etc.).
+    *   Parsing the kernel command line.
+    *   Calling `do_initcalls()` to run initialization functions from various kernel modules and subsystems.
+    *   Preparing the namespace (`prepare_namespace()`) which involves mounting the root filesystem.
+    *   Finally, attempting to execute the `init` process.
+
+*   **`calibrate.c`**: Contains the `calibrate_delay()` function, which determines the BogoMIPS value (a rough measure of CPU speed) by timing a busy-loop. This is used for certain short delays.
+
+*   **`do_mounts.c`**, **`do_mounts_*.c`**: These files handle the logic for finding and mounting the root filesystem. This can involve:
+    *   Mounting an initramfs (initial RAM filesystem) or initrd (initial RAM disk).
+    *   Parsing the `root=` kernel command line parameter.
+    *   Trying different file system types and devices.
+
+*   **`init_task.c`**: Defines the initial task structure (`init_task`) for process 0 (the swapper process or idle task).
+
+*   **`initramfs.c`**: Contains code related to populating the rootfs from an initramfs image that might be embedded in or loaded with the kernel.
+
+*   **`noinitramfs.c`**: Contains a stub `populate_rootfs` for when no initramfs is used.
+
+*   **`version.c`**: Manages the kernel version string, including information from the build process (build timestamp, hostname, etc.). It defines `linux_banner`, which is printed during boot.
+
+*   **`Kconfig`**: Kernel configuration options specific to the init process, such as support for initramfs.
+
+*   **`Makefile`**: Build rules for the files in this directory.
+
+## Use for Linux OS
+
+The code in the `init/` directory is executed very early in the Linux boot sequence. Its role is fundamental:
+
+1.  **Bridge from Bootloader to Full Kernel**: It takes over from the architecture-specific boot code and sets up a generic environment for the rest of the kernel to run.
+2.  **System Bootstrap**: Initializes critical subsystems without which the kernel cannot function (memory, scheduler, timers).
+3.  **Root Filesystem Mounting**: Locates and mounts the root filesystem, which contains the rest of the operating system and the `init` program. This is a pivotal step; without a root filesystem, the system cannot proceed to user space.
+4.  **Launching User Space**: It culminates in starting the first user-space process (PID 1), traditionally `/sbin/init`. This process is then responsible for starting system services, daemons, and eventually providing a login prompt or graphical environment.
+
+The `init/` directory essentially orchestrates the transition from a bare-metal environment (or the minimal state left by the bootloader) to a fully operational kernel ready to run user-space applications. Errors or failures in this stage are usually critical and prevent the system from booting successfully.

--- a/ipc/README.md
+++ b/ipc/README.md
@@ -1,0 +1,67 @@
+# ipc Directory
+
+The `ipc/` directory in the Linux kernel source tree contains the implementation of System V Inter-Process Communication (IPC) mechanisms. These mechanisms allow different processes running on the system to communicate and synchronize with each other.
+
+## Purpose
+
+The primary purpose of the `ipc/` directory is to provide kernel-level support for three classic IPC mechanisms inherited from System V UNIX:
+
+1.  **Message Queues**: Allow processes to exchange messages in a queue-like fashion.
+2.  **Semaphores**: Provide a way for processes to synchronize access to shared resources, typically by using semaphore sets (arrays of semaphores).
+3.  **Shared Memory**: Enable multiple processes to share a region of memory, allowing for very fast data exchange once the memory region is mapped into their address spaces.
+
+These IPC mechanisms are distinct from other communication methods like pipes, FIFOs, or sockets, and have their own unique APIs and kernel management.
+
+## Contents
+
+The `ipc/` directory is organized by the type of IPC mechanism:
+
+*   **`msg.c`** and **`msgutil.c`**: Implement System V message queues.
+    *   `msg.c`: Contains the core logic for message queue system calls (`msgsnd`, `msgrcv`, `msgget`, `msgctl`), message queue creation, permission handling, and data structure management.
+    *   `msgutil.c`: Provides utility functions used by `msg.c`.
+
+*   **`sem.c`**: Implements System V semaphores.
+    *   Handles system calls like `semop`, `semget`, `semctl`.
+    *   Manages semaphore sets, semaphore operations (incrementing, decrementing, waiting for zero), undo structures (to reverse semaphore operations if a process exits unexpectedly), and permission checking.
+
+*   **`shm.c`**: Implements System V shared memory.
+    *   Handles system calls like `shmat`, `shmdt`, `shmget`, `shmctl`.
+    *   Manages shared memory segments, attaching and detaching segments to process address spaces, and permission control.
+    *   Often interacts closely with the memory management subsystem (`mm/`) as it deals with mapping physical memory into virtual address spaces.
+
+*   **`ipc_sysctl.c`**: Implements sysctl interfaces for configuring System V IPC parameters (e.g., maximum number of message queues, maximum size of a shared memory segment). These are often exposed via `/proc/sys/kernel/`.
+
+*   **`mq_sysctl.c`**: Specifically handles sysctl parameters related to POSIX message queues (which are different from System V message queues, though this file resides here probably due to historical reasons or close relation).
+
+*   **`mqueue.c`**: Implements POSIX message queues (`mq_open`, `mq_send`, `mq_receive`, etc.). While POSIX message queues are standardized by POSIX and have a different API from System V message queues, their kernel implementation is located in this directory. They are often implemented using a special filesystem (`mqueuefs`).
+
+*   **`namespace.c`**: Implements IPC namespaces. This allows for isolating System V IPC objects (and POSIX message queues) within different namespaces, so that processes in one IPC namespace cannot see or interact with IPC objects in another. This is a key feature for containerization.
+
+*   **`util.c`** and **`util.h`**: Contain common utility functions and data structures used by the different System V IPC mechanisms. This includes:
+    *   Management of IPC identifiers (IDs).
+    *   Permission checking logic.
+    *   Locking mechanisms for synchronizing access to IPC data structures.
+    *   Creation and lookup of IPC objects.
+
+*   **`compat.c`**: Handles compatibility for System V IPC system calls made from 32-bit user-space applications running on a 64-bit kernel (or vice-versa, if applicable to an architecture).
+
+*   **`syscall.c`**: Registers the System V IPC system calls with the kernel.
+
+*   **`Kconfig`** and **`Makefile`**: Build system files for configuring and compiling the IPC code.
+
+## Use for Linux OS
+
+The System V IPC mechanisms provided by the code in this directory offer ways for processes to:
+
+*   **Exchange Data**:
+    *   **Message Queues**: Useful for sending formatted messages between processes. Messages are stored in the kernel until retrieved.
+    *   **Shared Memory**: The fastest way for processes to share large amounts of data, as data doesn't need to be copied between kernel and user space once the segment is mapped.
+
+*   **Synchronize**:
+    *   **Semaphores**: Used to control access to shared resources or to signal conditions between processes. They are more general than simple mutexes or spinlocks and can count resources.
+
+*   **Legacy and Specific Applications**: While newer IPC mechanisms (like POSIX IPC, sockets, or more advanced primitives) are often preferred for new development, System V IPC is still widely used by many existing applications, particularly database systems and other enterprise software that has a UNIX heritage.
+
+*   **Namespacing for Isolation**: IPC namespaces are crucial for containers (like Docker or LXC) to provide isolated environments where containers have their own sets of IPC objects, preventing interference between containers or with the host system.
+
+Although sometimes considered complex or having historical quirks, the System V IPC facilities remain a standard part of the Linux kernel, ensuring compatibility and providing powerful tools for inter-process communication and synchronization.

--- a/kernel/README.md
+++ b/kernel/README.md
@@ -1,0 +1,105 @@
+# kernel Directory
+
+The `kernel/` directory is the heart of the Linux kernel, containing the core, architecture-independent code that manages the system's fundamental operations. It deals with processes, scheduling, timekeeping, tracing, locking, and many other essential kernel functions.
+
+## Purpose
+
+The primary purpose of the `kernel/` directory is to provide the central logic for the operating system. It's responsible for:
+
+1.  **Process Management**: Creating, managing, and terminating processes and threads.
+2.  **Scheduling**: Deciding which process runs on the CPU at any given time.
+3.  **Synchronization**: Providing locking mechanisms (mutexes, spinlocks, semaphores, etc.) to protect shared data structures from concurrent access.
+4.  **Timekeeping**: Managing system time, timers, and delays.
+5.  **Signaling**: Implementing the signal mechanism for inter-process communication and event notification.
+6.  **Tracing and Profiling**: Providing frameworks like ftrace, perf_events, and kprobes for debugging, performance analysis, and dynamic tracing.
+7.  **Kernel Object Management**: Handling generic kernel objects and their lifecycles.
+8.  **Power Management**: Core infrastructure for CPU idling and system suspend/resume.
+9.  **Module Loading**: Although `module.c` is in `kernel/`, the full module loading infrastructure is more distributed.
+
+## Contents
+
+The `kernel/` directory is extensive and contains many critical files and subdirectories:
+
+*   **`sched/`**: This important subdirectory contains the kernel's process scheduler.
+    *   `core.c`: Core scheduler logic, including context switching, runqueue management, and load balancing.
+    *   `fair.c`: The Completely Fair Scheduler (CFS), the default scheduler for normal tasks.
+    *   `rt.c`: Real-time scheduler policies (FIFO and Round Robin).
+    *   `deadline.c`: Deadline scheduler.
+    *   `stop_machine.c`: Mechanism to safely stop all other CPUs.
+    *   Files related to CPU groups, CPU bandwidth control, and scheduling domains.
+
+*   **`time/`**: Code related to timekeeping and timers.
+    *   `time.c`: System time management, `jiffies`, and related functions.
+    *   `timer.c`: Kernel timers (soft timers).
+    *   `hrtimer.c`: High-resolution timers.
+    *   `tick-sched.c`, `tick-common.c`: Management of the system tick.
+    *   `clocksource.c`: Clock source management (abstracting hardware timers).
+
+*   **`fork.c`**: Implementation of the `fork()`, `vfork()`, and `clone()` system calls for creating new processes.
+*   **`exit.c`**: Code for process termination (`exit()`, `wait()`).
+*   **`signal.c`**: Core signal handling logic.
+*   **`sysctl.c`**: Kernel sysctl interface (for `/proc/sys`).
+*   **`printk/`**: Contains `printk.c` for kernel message printing and console logging.
+*   **`panic.c`**: Kernel panic handling.
+*   **`cpu.c`**: CPU hotplug support and management of per-CPU data.
+*   **`module/`**: Contains `module.c` which has core parts of the kernel module loading infrastructure.
+*   **`kthread.c`**: Kernel thread creation and management.
+*   **`workqueue.c`**: Kernel workqueue implementation for deferring work to process context.
+*   **`rcu/`**: Read-Copy-Update (RCU) synchronization mechanism implementation. RCU is a highly specialized and important locking primitive for read-mostly data.
+    *   `tree.c`, `rcu_segcblist.c`: Core RCU implementations.
+    *   `sync.c`: RCU synchronization primitives like `synchronize_rcu()`.
+
+*   **`locking/`**: Implementations of various locking primitives.
+    *   `mutex.c`: Mutexes.
+    *   `spinlock.c`: Spinlocks.
+    *   `rwsem.c`: Reader/writer semaphores.
+    *   `semaphore.c`: Semaphores.
+    *   `lockdep.c`: Lock validator for detecting potential deadlocks.
+
+*   **`trace/`**: The ftrace tracing infrastructure.
+    *   `trace.c`: Core ftrace engine.
+    *   `trace_events.c`: Static tracepoint implementation.
+    *   `trace_kprobe.c`: Kprobe-based dynamic events.
+    *   Many files for different tracers (function tracer, function graph tracer, latency tracers, etc.).
+
+*   **`events/`**: The perf_events subsystem for performance monitoring and profiling.
+    *   `core.c`: Core perf_events logic.
+    *   `hw_breakpoint.c`: Hardware breakpoint support.
+    *   `uprobes.c`: User-space probing.
+
+*   **`power/`**: Core power management infrastructure.
+    *   `main.c`: Main PM core logic.
+    *   `qos.c`: Quality of Service for power management.
+    *   `suspend.c`: System suspend/resume (sleep states).
+    *   `wakeirq.c`: Wakeup interrupt management.
+
+*   **`cgroup/`**: Control groups (cgroups) core implementation.
+    *   `cgroup.c`: Core cgroup logic.
+    *   Subdirectories for specific cgroup controllers (e.g., `cpuset.c`, `freezer.c`).
+
+*   **`bpf/`**: Berkeley Packet Filter (BPF) subsystem, including the in-kernel BPF verifier and JIT compilers (though architecture-specific JITs are in `arch/`).
+    *   `core.c`: BPF interpreter and core logic.
+    *   `verifier.c`: BPF program verifier.
+    *   `syscall.c`: `bpf()` system call implementation.
+    *   Files for different BPF map types and program types.
+
+*   **`livepatch/`**: Kernel live patching infrastructure.
+*   **`kexec_core.c`**: Core kexec functionality for booting into another kernel.
+*   **`pid.c`**: Process ID management.
+*   **`params.c`**: Kernel module parameter parsing.
+*   **`sys.c`**: Implementation of various system calls like `uname()`, `sysinfo()`.
+*   **`uid16.c`**: Support for legacy 16-bit UIDs/GIDs.
+
+## Use for Linux OS
+
+The `kernel/` directory is the engine room of Linux. It provides the essential services that all other parts of the system rely on:
+
+*   **Multitasking**: Manages the execution of multiple programs concurrently through processes and threads, and schedules their access to the CPU.
+*   **System Stability**: Handles errors, panics, and provides synchronization primitives to prevent data corruption in a concurrent environment.
+*   **Resource Management**: Controls access to CPU time and other fundamental system resources.
+*   **Time and Timers**: Provides the basis for all time-related operations, including scheduling, timeouts, and delays.
+*   **Debugging and Monitoring**: Offers powerful tools for developers and administrators to trace, profile, and debug the kernel and applications.
+*   **Extensibility**: Supports loadable kernel modules, allowing the kernel's functionality to be extended at runtime.
+*   **System Boot and Shutdown**: Plays a role in the orderly startup and shutdown of the system.
+
+The code in this directory is highly critical and complex, forming the foundation upon which the entire Linux operating system is built. Changes here require extreme care and thorough understanding due to their system-wide impact.

--- a/lib/README.md
+++ b/lib/README.md
@@ -1,0 +1,91 @@
+# lib Directory
+
+The `lib/` directory in the Linux kernel source tree contains generic helper functions and library routines that are used by various parts of the kernel. These functions provide common, reusable code for tasks that are not specific to any particular subsystem.
+
+## Purpose
+
+The primary purpose of the `lib/` directory is to:
+
+1.  **Provide common utility functions**: Offer implementations for standard operations like string manipulation, memory operations, sorting, checksums, data structure management (e.g., linked lists, bitmaps, FIFOs), and more.
+2.  **Reduce code duplication**: By centralizing these common routines, the kernel avoids redundant implementations across different subsystems.
+3.  **Offer optimized routines**: Some library functions, particularly those for memory and string operations, may have architecture-specific optimized versions (found in `arch/<architecture>/lib/`) that are selected at compile time, while `lib/` provides the generic C fallbacks.
+4.  **Implement generic data structures and algorithms**: Provide well-tested implementations of fundamental data structures and algorithms.
+
+## Contents
+
+The `lib/` directory contains a wide range of C files, each typically implementing a related set of functions or a specific data structure. Key components include:
+
+*   **String manipulation (`string.c`, `strscpy.c`, etc.)**:
+    *   Functions like `strcpy`, `strncpy`, `strcat`, `strcmp`, `strlen`, `strchr`, `strstr`, `strnlen`, `strlcpy`, `strscpy`, `strreplace`.
+    *   Memory operations often grouped with strings: `memcpy`, `memmove`, `memset`, `memcmp`, `memchr`.
+
+*   **Bitmap operations (`bitmap.c`)**: Functions for manipulating bitmaps (arrays of bits), such as `bitmap_set`, `bitmap_clear`, `bitmap_find_next_zero_area`.
+
+*   **Checksums (`checksum.c`, `crc32.c`, `crc-t10dif.c`, `crc16.c`, `crc7.c`, `crc8.c`, `raid6/`)**:
+    *   Generic IP checksum (`ip_compute_csum`).
+    *   Cyclic Redundancy Check (CRC) implementations (CRC32, CRC16, etc.).
+    *   RAID6 syndrome calculation routines.
+
+*   **Sorting (`sort.c`)**: A generic `sort()` function (typically heapsort or similar).
+
+*   **Linked list debugging (`list_debug.c`)**: Debugging checks for the kernel's standard linked list implementation (defined in `include/linux/list.h`).
+
+*   **FIFO (First-In, First-Out) buffers (`kfifo.c`)**: Implementation of a generic, lockless FIFO buffer.
+
+*   **Integer operations and properties (`math/`, `div64.c`, `clz_ctz.c`)**:
+    *   64-bit division (`do_div`).
+    *   Counting leading/trailing zeros.
+    *   Integer square root.
+
+*   **Compression/Decompression libraries (`lzo/`, `zlib_inflate/`, `zlib_deflate/`, `xz/`, `zstd/`, `842/`)**:
+    *   Implementations of various compression algorithms used within the kernel (e.g., for initramfs, compressed kernel image, btrfs/zram compression).
+
+*   **Error handling and debugging (`bug.c`, `dump_stack.c`)**:
+    *   `BUG()` and `WARN_ON()` macros and their support.
+    *   Stack dumping utilities.
+
+*   **Hashing (`jhash.c`, `siphash.c`)**: Implementations of different hash functions.
+
+*   **IDR and IDA (`idr.c`)**: Integer IDR (ID Radix) and IDA (ID Allocator) for managing small integer IDs.
+
+*   **Rate limiting (`ratelimit.c`)**: Utilities for rate-limiting messages or events.
+
+*   **Text searching (`textsearch.c`)**: Kernel text search Boyer-Moore algorithm.
+
+*   **CPU masks (`cpumask.c`)**: Functions for manipulating `cpumask_t` types, used to represent sets of CPUs.
+
+*   **ASN.1 parser (`asn1_decoder.c`)** and **encoder (`asn1_encoder.c`)**: For handling Abstract Syntax Notation One data, often used in security protocols.
+
+*   **JSON parser (`json.c`, `json_writer.c`)**: For parsing and generating JSON-formatted data.
+
+*   **SG (Scatter-Gather) list utilities (`sg_pool.c`, `sg_split.c`)**: Helper functions for managing scatter-gather lists used in DMA operations.
+
+*   **`vsprintf.c`**: Core implementation of `vsprintf` and related formatted printing functions (though `printk` itself is in `kernel/printk/`).
+
+*   **`kobject.c`**: Parts of the kobject infrastructure (though the main kobject handling is in `drivers/base/`).
+
+*   **`nmi_backtrace.c`**: Backtrace generation from NMI context.
+
+*   **`parser.c`**: Utilities for parsing simple command-line like strings.
+
+*   **`sha1.c`, `sha256.c`, `sha512.c`**: Software implementations of SHA hashing algorithms (used if hardware acceleration is not available).
+
+*   **`radix-tree.c`, `maple_tree.c`**: Implementations of radix trees and maple trees, which are space-efficient data structures for storing items indexed by integer keys.
+
+*   **`argv_split.c`**: For splitting a string into an argument vector.
+
+*   **`fonts/`**: Contains font data that can be used by the kernel (e.g., for the framebuffer console).
+
+*   **`assoc_array.c`**: Associative array implementation.
+
+## Use for Linux OS
+
+The `lib/` directory provides the foundational building blocks for many kernel operations:
+
+*   **Efficiency**: Offers optimized routines for common tasks, improving overall kernel performance.
+*   **Correctness**: Provides well-tested and debugged implementations of standard algorithms and data structures, reducing the likelihood of bugs in higher-level code.
+*   **Code Reusability**: Prevents developers from reinventing the wheel, leading to a smaller, more maintainable kernel codebase.
+*   **Portability**: While some functions have architecture-specific overrides, the generic C versions in `lib/` ensure that the kernel can be compiled and run on new architectures more easily.
+*   **Essential Services**: Functions like string manipulation, memory operations, and data structure management are fundamental to almost every part of the kernel, from device drivers to file systems to networking.
+
+The code in `lib/` is generally expected to be highly reliable, efficient, and broadly applicable across the kernel. It forms a layer of common software infrastructure that supports the more specialized parts of the operating system.

--- a/mm/README.md
+++ b/mm/README.md
@@ -1,0 +1,60 @@
+# mm Directory
+
+The `mm/` directory in the Linux kernel source tree is dedicated to memory management. It contains the core logic for how the kernel handles physical and virtual memory, including allocation, deallocation, paging, swapping, and various other memory-related operations.
+
+## Purpose
+
+The primary purpose of the `mm/` directory is to:
+
+1.  **Manage physical memory**: Keep track of available and used physical memory pages.
+2.  **Implement virtual memory**: Provide each process with its own isolated virtual address space and manage the mapping between virtual and physical addresses (paging).
+3.  **Handle memory allocation**: Offer mechanisms for both kernel-internal memory allocation (e.g., slab allocators, vmalloc) and user-space memory requests (e.g., `mmap()`, `brk()`).
+4.  **Implement swapping and page reclamation**: Move less-used memory pages to secondary storage (swap space) to free up physical memory, and reclaim pages for reuse.
+5.  **Manage the page cache**: Cache file data in memory to speed up disk I/O.
+6.  **Provide memory-related system calls**: Implement system calls like `mmap()`, `munmap()`, `mprotect()`, `brk()`, `sbrk()`.
+7.  **Support advanced memory features**: Handle features like Non-Uniform Memory Access (NUMA), hugetlbpages (large pages), memory hotplug, and memory protection.
+
+## Contents
+
+The `mm/` directory is one of the most complex and critical parts of the kernel. Key files and subdirectories include:
+
+*   **`memory.c`**: Core memory management functions, including page fault handling (`do_page_fault()`), page table manipulation helpers, and functions related to `mmap()` and `munmap()`.
+*   **`page_alloc.c`**: The buddy allocator, which is the primary physical page allocator in the kernel. It manages free pages of different orders (powers of 2).
+*   **`slab.c`, `slub.c`, `slob.c`**: Implementations of slab allocators. These are used for allocating kernel objects of specific sizes, reducing fragmentation and improving performance compared to direct page allocation for small objects. `slub.c` is the modern default.
+*   **`vmalloc.c`**: Implements `vmalloc()`, which allocates virtually contiguous but physically non-contiguous memory regions in the kernel's address space. Useful for large, but not performance-critical, kernel allocations.
+*   **`filemap.c`**: Manages the page cache, which caches file data read from or written to disk.
+*   **`swap.c`, `swap_state.c`, `swapfile.c`**: Implement the swapping mechanism, including page-out to swap devices, page-in from swap, and management of swap spaces.
+*   **`mmap.c`**: Handles memory mapping for processes, including the `mmap()` system call logic and management of Virtual Memory Areas (VMAs).
+*   **`mprotect.c`**: Implements the `mprotect()` system call for changing memory protection flags.
+*   **`msync.c`**: Implements the `msync()` system call for synchronizing memory-mapped regions with their backing store.
+*   **`shmem.c`**: Implements `tmpfs` (a RAM-based filesystem) and System V shared memory (though the IPC-specific parts are in `ipc/shm.c`).
+*   **`huge_memory.c`, `hugetlb.c`, `hugetlb_cgroup.c`**: Support for hugetlbpages, which are large physical pages (e.g., 2MB or 1GB instead of the usual 4KB) that can improve performance for applications with large memory footprints by reducing TLB pressure.
+*   **`mempolicy.c`, `memcontrol.c` (and `cma.c`, `damon/`)**: NUMA (Non-Uniform Memory Access) memory policy management and memory control groups (memcg) for resource limiting. `damon/` implements Data Access MONitor.
+*   **`migrate.c`**: Code for migrating pages between physical memory locations, often used for NUMA balancing or memory hot-remove.
+*   **`page-writeback.c`**: Manages the writing of dirty pages from the page cache back to disk.
+*   **`readahead.c`**: Implements file readahead to proactively fetch file data into the page cache.
+*   **`workingset.c`**: Logic for tracking the working set of processes (actively used memory).
+*   **`ksm.c`**: Kernel Samepage Merging, a feature that deduplicates identical memory pages.
+*   **`meminit.c` (in `arch/<arch>/mm/`) and `nobootmem.c`**: Early memory initialization. (`bootmem.c` is older).
+*   **`kasan/`, `kfence/`, `kmsan/`**: Kernel Address Sanitizer (KASan), Kernel Electric-Fence (KFENCE), and Kernel Memory Sanitizer (KMSAN) for detecting memory errors.
+*   **`percpu.c`**: Per-CPU variable allocation.
+*   **`zswap.c`, `zsmalloc.c`, `zbud.c`, `z3fold.c`**: Components related to compressed RAM swapping/caching.
+*   **`gup.c`**: Functions for `get_user_pages()`, which pin user-space pages in memory for direct kernel access (e.g., for DMA).
+*   **`nommu.c`**: Memory management for systems without an MMU (Memory Management Unit), common in some embedded systems.
+*   **`mremap.c`**: Implements the `mremap()` system call for resizing or moving memory mappings.
+*   **`compaction.c`**: Memory compaction, which tries to create larger contiguous free memory blocks.
+*   **`userfaultfd.c`**: User-space page fault handling.
+*   **`memblock.c`**: Early memory allocator used before the buddy system is fully operational.
+
+## Use for Linux OS
+
+The memory management subsystem is one of the most fundamental parts of the Linux kernel. It is responsible for:
+
+*   **Process Isolation**: Giving each process its own virtual address space, preventing processes from interfering with each other's memory.
+*   **Efficient Memory Usage**: Allocating and deallocating memory efficiently, minimizing fragmentation, and using techniques like swapping and page caching to make the most of available RAM.
+*   **Abstracting Hardware**: Providing a consistent view of memory to the rest of the kernel and user space, regardless of the underlying hardware specifics (though `arch/<arch>/mm/` handles the hardware details).
+*   **Performance**: Optimizing memory access patterns, reducing page faults, and speeding up I/O through caching.
+*   **Security**: Enforcing memory protection (read, write, execute permissions) and providing mechanisms like ASLR (Address Space Layout Randomization).
+*   **Resource Control**: Allowing administrators to set limits on memory usage for processes or groups of processes (cgroups).
+
+The `mm/` directory contains the code that makes all of this possible. It is a highly complex area of the kernel, and changes here can have profound effects on system stability, performance, and security. Developers working in this area require a deep understanding of both software algorithms and hardware memory architectures.

--- a/net/README.md
+++ b/net/README.md
@@ -1,0 +1,107 @@
+# net Directory
+
+The `net/` directory in the Linux kernel source tree is the home of the kernel's networking subsystem. It contains the implementations of various network protocols, network device management, socket layers, and other networking-related functionalities.
+
+## Purpose
+
+The primary purpose of the `net/` directory is to:
+
+1.  **Implement Network Protocols**: Provide the core logic for a wide range of network protocols, including TCP/IP (IPv4 and IPv6), UDP, ICMP, ARP, Ethernet, Wi-Fi (in conjunction with `drivers/net/wireless/`), Bluetooth networking, and many others.
+2.  **Manage Network Devices**: Handle the registration, configuration, and operation of network interface controllers (NICs) through the `netdevice` abstraction.
+3.  **Provide Socket APIs**: Implement the socket layer, which is the primary interface for user-space applications to perform network communication (e.g., `socket()`, `bind()`, `connect()`, `send()`, `recv()`).
+4.  **Handle Packet Processing**: Manage the flow of network packets through the system, including routing, forwarding, filtering (Netfilter/iptables/nftables), and queueing.
+5.  **Support Network Address Translation (NAT) and Connection Tracking**: Implement mechanisms for modifying network addresses and tracking network connections.
+6.  **Offer Network Utilities and Management Interfaces**: Provide tools and interfaces (e.g., via procfs, sysfs, netlink) for configuring and monitoring the networking subsystem.
+
+## Contents
+
+The `net/` directory is very large and complex, reflecting the richness of Linux's networking capabilities. It is organized into numerous subdirectories, typically based on protocol families or functional areas:
+
+*   **`core/`**: Core networking infrastructure.
+    *   `dev.c`: Network device management (registration, activation, deactivation).
+    *   `skbuff.c`: Socket buffer (`sk_buff`) management, the fundamental data structure for network packets.
+    *   `sock.c`: Generic socket layer implementation.
+    *   `netfilter.c`: Core Netfilter hooks and infrastructure.
+    *   `rtnetlink.c`: Netlink interface for routing and network device configuration.
+    *   `sysctl_net_core.c`: Sysctl parameters for core networking.
+    *   `gro.c`, `gso.c`: Generic Receive Offload and Generic Segmentation Offload.
+
+*   **`ipv4/`**: Implementation of the IPv4 protocol suite.
+    *   `af_inet.c`: Address Family INET (IPv4) socket layer.
+    *   `ip_input.c`, `ip_output.c`, `ip_forward.c`: IPv4 packet reception, transmission, and forwarding.
+    *   `route.c`: IPv4 routing table management.
+    *   `tcp_ipv4.c`, `udp.c`, `ping.c` (for raw ICMP sockets): TCP, UDP, and ICMP implementations over IPv4.
+    *   `arp.c`: Address Resolution Protocol.
+    *   `netfilter/`: IPv4-specific Netfilter modules (iptables).
+
+*   **`ipv6/`**: Implementation of the IPv6 protocol suite.
+    *   `af_inet6.c`: Address Family INET6 (IPv6) socket layer.
+    *   `ip6_input.c`, `ip6_output.c`, `ip6_forward.c`: IPv6 packet processing.
+    *   `route.c`: IPv6 routing.
+    *   `tcp_ipv6.c`, `udp.c` (shared with IPv4 but with IPv6 specifics): TCP and UDP over IPv6.
+    *   `ndisc.c`: Neighbor Discovery Protocol.
+    *   `netfilter/`: IPv6-specific Netfilter modules (ip6tables).
+
+*   **`bridge/`**: Ethernet bridging implementation (software switch).
+*   **`dsa/`**: Distributed Switch Architecture, for managing switch hardware.
+*   **`ethernet/`**: Ethernet-specific functionalities (`eth.c`).
+*   **`llc/`**: Logical Link Control (IEEE 802.2).
+*   **`sched/`**: Network traffic scheduling (queueing disciplines, qdiscs).
+    *   Contains implementations of various qdiscs like `sch_fq_codel.c`, `sch_htb.c`, `sch_ingress.c`.
+
+*   **`netfilter/`**: Core Netfilter framework and common components.
+    *   `nf_conntrack_core.c`: Connection tracking.
+    *   `nf_nat_core.c`: Network Address Translation core.
+    *   `x_tables.c`: The `xtables` framework used by iptables, ip6tables, arptables, ebtables.
+    *   Subdirectories for specific Netfilter modules and helpers.
+
+*   **`nftables/`**: The `nftables` packet filtering framework, which is replacing `iptables`.
+*   **`xfrm/`**: IPsec (IP Security) framework for secure network communication.
+    *   `xfrm_input.c`, `xfrm_output.c`, `xfrm_policy.c`, `xfrm_state.c`.
+
+*   **`socket.c`**: Generic socket system call implementations (the top-level interface).
+*   **`sysctl_net.c`**: Top-level sysctl entries for networking.
+
+*   **Protocol-specific directories**:
+    *   `ax25/`: AX.25 packet radio protocol.
+    *   `bluetooth/`: Bluetooth networking protocols (e.g., L2CAP, SCO, RFCOMM, BNEP). (Works in conjunction with `drivers/bluetooth/`).
+    *   `caif/`: Communication CPU Abstraction Interface Framework (used by some modems).
+    *   `can/`: Controller Area Network (CAN bus) protocols.
+    *   `dccp/`: Datagram Congestion Control Protocol.
+    *   `ieee802154/`: IEEE 802.15.4 and 6LoWPAN.
+    *   `lapb/`: Link Access Procedure, Balanced (X.25).
+    *   `l2tp/`: Layer 2 Tunneling Protocol.
+    *   `mac80211/`: Software MAC for IEEE 802.11 (Wi-Fi). This is a major component for Wi-Fi drivers.
+    *   `mptcp/`: Multipath TCP.
+    *   `ncsi/`: Network Controller Sideband Interface.
+    *   `netlink/`: Netlink socket protocol implementation.
+    *   `netrom/`: NET/ROM amateur radio protocol.
+    *   `nfc/`: Near Field Communication protocols.
+    *   `openvswitch/`: Open vSwitch datapath.
+    *   `packet/`: Raw packet sockets (`AF_PACKET`).
+    *   `phonet/`: Phonet protocol (used in some Nokia phones).
+    *   `rose/`: X.25 PLP Rose.
+    *   `rds/`: Reliable Datagram Sockets.
+    *   `rxrpc/`: RxRPC protocol (AFS).
+    *   `sctp/`: Stream Control Transmission Protocol.
+    *   `smc/`: Shared Memory Communications (SMC) over RDMA.
+    *   `sunrpc/`: Sun Remote Procedure Call (RPC), used by NFS.
+    *   `tipc/`: Transparent Inter-Process Communication.
+    *   `unix/`: UNIX domain sockets (`AF_UNIX`).
+    *   `vmw_vsock/`: VMware VSockets.
+    *   `wireless/`: Wireless extensions (legacy Wi-Fi configuration, cfg80211 is the modern way).
+    *   `xdp/`: XDP (eXpress Data Path) for high-performance packet processing.
+
+## Use for Linux OS
+
+The `net/` directory is fundamental to all network communication in Linux:
+
+*   **Internet and Local Networking**: Enables communication over Ethernet, Wi-Fi, and other network media using TCP/IP and related protocols.
+*   **Application Communication**: Provides the socket API that most network-aware applications use to send and receive data.
+*   **Network Services**: Supports the implementation of network services like web servers, file servers (NFS, Samba), DNS resolvers, etc.
+*   **Security**: Implements firewalls (Netfilter/nftables) and secure communication protocols (IPsec).
+*   **Virtualization and Containers**: Provides networking for virtual machines and containers, including virtual switches and network namespaces.
+*   **Specialized Networking**: Supports a wide array of less common or specialized network protocols used in various domains (e.g., amateur radio, industrial control, automotive).
+*   **Network Management**: Offers interfaces for administrators to configure, monitor, and troubleshoot network behavior.
+
+The networking subsystem is a cornerstone of modern computing, and the `net/` directory contains the vast and intricate machinery that makes Linux a powerful networking platform. Its modular design allows for continuous addition and improvement of protocols and features.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,79 @@
+# scripts Directory
+
+The `scripts/` directory in the Linux kernel source tree contains a collection of scripts and small utility programs used primarily during the kernel build process, for development assistance, and for various administrative or debugging tasks.
+
+## Purpose
+
+The primary purposes of the `scripts/` directory are:
+
+1.  **Support the Kernel Build Process (Kbuild)**: Many scripts are integral to compiling the kernel, managing dependencies, generating configuration files, linking the final kernel image, and building modules.
+2.  **Development Aids**: Provide tools for kernel developers, such as code style checkers, patch manipulation utilities, and debugging aids.
+3.  **Configuration Management**: Scripts for handling kernel configuration (`.config` file), including `menuconfig`, `nconfig`, `xconfig`-like interfaces (though the C sources for these are often elsewhere, e.g., `scripts/kconfig/`).
+4.  **Packaging and Installation**: Scripts to help with packaging the kernel or installing modules.
+5.  **Documentation Generation**: Tools used in the process of generating kernel documentation.
+6.  **Miscellaneous Utilities**: Various other helper scripts for specific tasks related to kernel development or analysis.
+
+## Contents
+
+The `scripts/` directory is diverse, containing shell scripts (Bash, sh), Perl scripts, Python scripts, and some small C programs. Key components and subdirectories include:
+
+*   **Core Build Scripts (directly in `scripts/`)**:
+    *   `Makefile.*`: Various Makefiles included by the main kernel Makefile to define build rules for different stages or components (e.g., `Makefile.build`, `Makefile.clean`, `Makefile.host`, `Makefile.modpost`).
+    *   `mkconfigs`: Script to generate configuration header files.
+    *   `mod/`: Contains `modpost.c` (used to process modules during build) and related scripts.
+    *   `link-vmlinux.sh`: Script responsible for linking the final `vmlinux` kernel image.
+    *   `recordmcount.pl`: Perl script for processing mcount call sites for ftrace.
+    *   `setlocalversion`: Script to determine the local version string to append to the kernel version (e.g., based on Git tags or local changes).
+    *   `extract-certs`: Script to extract signing keys from the kernel image.
+    *   `extract-ikconfig`: Script to extract the in-kernel config (`.config`) from a `vmlinux` image.
+
+*   **`kconfig/`**: Contains the source code for the Kconfig utilities (`conf`, `mconf`, `nconf`) that are used to parse `Kconfig` files and generate the kernel `.config` file. These provide text-based and ncurses-based configuration interfaces.
+    *   `conf.c`: The 'conf' utility (e.g., for `make oldconfig`).
+    *   `mconf.c`: The 'mconf' utility (for `make menuconfig`).
+    *   `nconf.c`: The 'nconf' utility (for `make nconfig`).
+    *   `parser.y`, `lexer.l`: Lexer and parser for Kconfig files.
+
+*   **`dtc/`**: Device Tree Compiler (DTC) source code. DTC is used to compile Device Tree Source (`.dts`) files into Device Tree Blobs (`.dtb`) which are used by the kernel to discover and configure hardware on many platforms (especially ARM, PowerPC, RISC-V).
+
+*   **`checkpatch.pl`**: A Perl script that checks patches and code for conformance to the Linux kernel coding style.
+*   **`get_maintainer.pl`**: A Perl script that helps identify the maintainers and mailing lists relevant to a given file or patch.
+
+*   **`gdb/`**: Scripts to aid in debugging the kernel with GDB (GNU Debugger), such as pretty-printers for kernel data structures.
+
+*   **`package/`**: Scripts to help create kernel packages for various distributions (e.g., `builddeb` for Debian packages, `buildrpm` for RPM packages).
+
+*   **`selftests/`**: Infrastructure and scripts for running kernel selftests (though the actual tests are mostly in `tools/testing/selftests/`).
+
+*   **`tracing/`**: Scripts related to kernel tracing, often for use with ftrace or perf.
+
+*   **`pahole/` (if enabled)**: Scripts related to `pahole` (Poke-A-Hole), a tool for analyzing and reducing data structure padding and improving cache performance.
+
+*   **`rust/`**: Scripts specific to building Rust code within the kernel.
+
+*   **`coccinelle/`**: Scripts and Semantic Patches (SP) for use with Coccinelle, a tool for automated code transformation and analysis.
+
+*   **`decode_stacktrace.sh`**: A shell script to decode kernel oops messages and stack traces using a System.map file.
+
+*   **`genksyms/`**: Contains `genksyms.c`, used for generating symbol version information (CRCs) for modules if `CONFIG_MODVERSIONS` is enabled.
+
+*   **`headers_install.sh`**: Script responsible for installing the sanitized kernel headers (UAPI headers) to a specified location.
+
+*   **`kernel-doc`**: A Perl script used to extract kernel-doc comments from source code to generate documentation.
+
+*   **`pahole-flags.sh`**: Script to determine appropriate flags for `pahole`.
+
+*   **`resource_tool.py`**: Python script for managing Windows-style resource files, sometimes used for UEFI.
+
+## Use for Linux OS
+
+While most scripts in the `scripts/` directory are not directly part of the running Linux OS, they are indispensable for its development, compilation, and maintenance:
+
+*   **Kernel Compilation**: The Kbuild system heavily relies on these scripts to manage the complex process of building the kernel for numerous architectures and configurations.
+*   **Kernel Configuration**: `scripts/kconfig/` provides the tools that allow users to customize kernel features.
+*   **Device Tree**: `scripts/dtc/` is essential for systems that use Device Trees to describe their hardware.
+*   **Developer Workflow**: Scripts like `checkpatch.pl` and `get_maintainer.pl` are standard tools for kernel developers to ensure code quality and proper patch submission.
+*   **Debugging**: GDB scripts and stack trace decoders aid in diagnosing kernel issues.
+*   **Packaging**: Facilitates the creation of distributable kernel packages.
+*   **Maintaining Code Quality**: Coding style checkers and other analysis tools help maintain a consistent and high-quality codebase.
+
+The `scripts/` directory is a critical support system for the Linux kernel, enabling its development, customization, and distribution across a vast and diverse ecosystem.

--- a/security/README.md
+++ b/security/README.md
@@ -1,0 +1,66 @@
+# security Directory
+
+The `security/` directory in the Linux kernel source tree is dedicated to security-related code, primarily focusing on the Linux Security Modules (LSM) framework and various security subsystems that enhance the kernel's security capabilities.
+
+## Purpose
+
+The primary purposes of the `security/` directory are:
+
+1.  **Implement Mandatory Access Control (MAC)**: Provide the infrastructure and specific implementations for MAC systems. MAC systems allow for defining fine-grained access control policies that go beyond the standard Discretionary Access Control (DAC) provided by user/group permissions.
+2.  **Enhance Kernel Security**: Introduce various mechanisms to harden the kernel and protect against different types of attacks or vulnerabilities.
+3.  **Provide Security Auditing**: Integrate with auditing frameworks to log security-relevant events.
+4.  **Manage Security-Sensitive Kernel Objects**: Handle security aspects of kernel objects like keys and credentials.
+
+## Contents
+
+The `security/` directory is structured around the LSM framework and specific security modules/subsystems:
+
+*   **`security.c`**: The core of the LSM framework. It defines the hooks that are placed throughout the kernel code at points where security decisions need to be made (e.g., before accessing a file, sending a signal, or performing a network operation). When such a hook is triggered, the LSM framework calls out to the registered security module(s) to get a decision.
+*   **`lsm_audit.c`**: Provides helper functions for LSM modules to log audit messages.
+*   **`commoncap.c`**: Generic capability checking logic used by some LSMs.
+*   **`inode.c`**: Security-related aspects of inode management, often used by LSMs to store security labels on files.
+
+*   **LSM Module Subdirectories**: Each subdirectory typically represents a specific security module that can be enabled and stacked (some can be primary, others secondary).
+    *   **`selinux/`**: SELinux (Security-Enhanced Linux), a comprehensive MAC system developed by the NSA. It uses security labels and a detailed policy to enforce access controls.
+    *   **`smack/`**: Smack (Simplified Mandatory Access Control Kernel), another label-based MAC system designed for simplicity.
+    *   **`apparmor/`**: AppArmor, a path-name based MAC system that uses profiles to restrict program capabilities.
+    *   **`tomoyo/`**: TOMOYO Linux, a path-name based MAC system focused on learning mode and behavior analysis.
+    *   **`loadpin/`**: An LSM that ensures all kernel modules and firmware are loaded from a trusted, unwriteable source (e.g., a read-only rootfs or specific partition), preventing unauthorized code loading.
+    *   **`yama/`**: An LSM that provides additional restrictions, primarily on `ptrace` (process tracing) scope to limit information leakage or unauthorized process manipulation.
+    *   **`safesetid/`**: An LSM that restricts UID/GID transitions (setuid/setgid) to mitigate risks associated with privilege escalation.
+    *   **`bpf/`**: Contains LSM hooks specifically for BPF (Berkeley Packet Filter) operations, allowing security modules to control BPF program loading and map access.
+    *   **`landlock/`**: A sandboxing LSM that allows unprivileged processes to restrict their own ambient capabilities regarding file system access, network access, etc.
+
+*   **`integrity/`**: Kernel integrity subsystem.
+    *   **`ima/`**: Integrity Measurement Architecture (IMA). IMA can measure (hash) files before they are executed or mmaped and can appraise (verify signatures of) files against a trusted keyring.
+    *   **`evm/`**: Extended Verification Module (EVM). EVM protects file metadata and security extended attributes (xattrs) by signing them, preventing offline tampering.
+    *   `digsig.c`: Digital signature verification.
+    *   `platform_certs/`: Code for loading platform-provided certificates (e.g., from UEFI).
+
+*   **`keys/`**: Kernel key retention service.
+    *   `key.c`, `keyring.c`: Core key and keyring management.
+    *   `request_key.c`: Mechanism for user space to request keys from the kernel or for the kernel to upcall to user space to get a key.
+    *   `encrypted-keys/`: Support for encrypting/decrypting kernel keys.
+    *   `trusted-keys/`: Support for keys that are protected by hardware (like a TPM) or a trusted subsystem.
+
+*   **`lockdown/`**: Kernel lockdown mechanism. When enabled, it restricts certain kernel features that could be used to compromise the running kernel, even by UID 0. This is particularly relevant for UEFI Secure Boot environments.
+
+*   **`min_addr.c`**: Implements restrictions on the minimum virtual memory address accessible to user-space, helping to mitigate null-pointer dereference exploits.
+
+*   **`device_cgroup.c`**: While cgroups are primarily in `kernel/cgroup/`, this file implements the device controller for cgroups, which allows restricting access to device nodes.
+
+*   **`Kconfig`**, **`Makefile`**: Build system files for configuring and compiling security features and LSMs.
+
+## Use for Linux OS
+
+The `security/` directory provides mechanisms that significantly enhance the security posture of a Linux system:
+
+*   **Mandatory Access Control**: LSMs like SELinux, AppArmor, and Smack allow administrators to define and enforce security policies that are more granular and robust than standard UNIX permissions. This helps in containing breaches and limiting the capabilities of processes.
+*   **Integrity Protection**: IMA and EVM help ensure the integrity of the running system by detecting unauthorized modifications to files and metadata.
+*   **Secure Key Management**: The kernel key service provides a secure way to store and manage sensitive information like encryption keys and authentication tokens.
+*   **Hardening**: Features like kernel lockdown, `ptrace` restrictions (Yama), and `setuid` restrictions (SafeSetID) reduce the attack surface of the kernel.
+*   **Sandboxing**: Landlock provides a way for applications to voluntarily restrict their own privileges, improving security through principle of least privilege.
+*   **Auditing**: Integration with the audit framework ensures that security-relevant actions can be logged and reviewed.
+*   **Trusted Computing**: Support for TPMs and trusted keys enables features that rely on a hardware root of trust.
+
+The LSM framework is a key design feature, allowing different security models to be plugged into the kernel without modifying the core kernel code. This modularity means that users can choose the security module that best fits their needs, or even stack multiple modules for layered security (though typically only one "major" MAC module is active at a time). The components in this directory are crucial for building secure Linux systems, especially in environments with stringent security requirements.

--- a/sound/README.md
+++ b/sound/README.md
@@ -1,0 +1,83 @@
+# sound Directory
+
+The `sound/` directory in the Linux kernel source tree contains the Advanced Linux Sound Architecture (ALSA), which is the primary framework for sound card device drivers and audio functionality in Linux. It also contains remnants of the older Open Sound System (OSS) for compatibility.
+
+## Purpose
+
+The primary purpose of the `sound/` directory is to:
+
+1.  **Provide a driver framework for sound hardware**: ALSA offers a modular architecture for developing drivers for a wide variety of sound cards, codecs, and audio interfaces (e.g., PCI, USB, I2S, HD-Audio).
+2.  **Expose audio capabilities to user space**: It provides APIs (primarily through character devices in `/dev/snd/`) for applications to play and record audio, control mixer settings, and access MIDI (Musical Instrument Digital Interface) functionality.
+3.  **Manage audio resources**: Handle the complexities of audio routing, synchronization, and hardware abstraction.
+4.  **Support advanced audio features**: Implement features like hardware mixing/capture, MIDI sequencing, and digital audio interfaces (S/PDIF).
+
+## Contents
+
+The `sound/` directory is large and organized into several subdirectories, reflecting the layered architecture of ALSA:
+
+*   **`core/`**: The heart of ALSA.
+    *   `pcm_native.c`, `pcm_lib.c`, `pcm_memory.c`: Core PCM (Pulse Code Modulation) playback and capture implementation. PCM is the standard format for digital audio.
+    *   `control.c`: Control interface for mixers, switches, and other sound card controls.
+    *   `timer.c`: ALSA timer implementation, crucial for MIDI sequencing and precise audio timing.
+    *   `rawmidi.c`: Raw MIDI interface.
+    *   `hwdep.c`: Hardware-dependent device interface.
+    *   `device.c`: ALSA device registration and management.
+    *   `info.c`: Procfs interface (`/proc/asound/`) for ALSA information.
+    *   `seq/`: The ALSA sequencer, a powerful framework for MIDI event routing and processing.
+        *   `seq_clientmgr.c`, `seq_ports.c`, `seq_queue.c`, `seq_timer.c`, `seq_midi_emul.c`.
+    *   `oss/`: OSS compatibility layer (emulates OSS devices using ALSA).
+
+*   **`drivers/`**: Generic (bus-independent) ALSA driver components.
+    *   `aloop.c`: A loopback sound card for testing and routing audio within the system.
+    *   `dummy.c`: A dummy sound card driver.
+    *   `opl3/`, `opl4/`: Drivers for Yamaha OPL3/OPL4 FM synthesizers.
+    *   `pcsp/`: PC speaker driver.
+    *   `virmidi.c`: Virtual MIDI driver.
+
+*   **`isa/`**: Drivers for sound cards connected via the ISA bus (mostly legacy).
+    *   Subdirectories for specific chipsets like `ad1848/`, `cs423x/`, `es1688/`, `gus/`, `sb/` (Sound Blaster).
+
+*   **`pci/`**: Drivers for sound cards and audio chipsets connected via the PCI/PCIe bus. This is a major category.
+    *   `hda/`: High Definition Audio (Intel HDA) drivers, which are very common for modern onboard audio and HDMI audio.
+        *   `hda_codec.c`, `hda_intel.c`, `patch_*.c` (codec-specific patches).
+    *   Subdirectories for various PCI sound card chipsets like `als4000.c`, `au88x0/` (Aureal Vortex), `ca0106/` (Sound Blaster Audigy LS), `emu10k1/` (Sound Blaster Live!/Audigy), `ice1712/` (Envy24), `oxygen/` (C-Media Oxygen HD), `riptide.c`, `ymfpci.c` (Yamaha YMF7xx).
+
+*   **`usb/`**: Drivers for USB audio and MIDI devices.
+    *   `card.c`, `mixer.c`, `pcm.c`, `midi.c`: Core USB audio class driver components.
+    *   `quirks.c`: Handles quirks for specific USB audio devices that don't perfectly follow the USB audio class specification.
+    *   Subdirectories for specific USB device families or complex devices, e.g., `caiaq/` (Native Instruments), `line6/`.
+
+*   **`spi/`**: Drivers for audio codecs connected via the SPI bus.
+*   **`i2c/`**: Drivers for audio codecs and components controlled via the I2C bus (often used in conjunction with other bus drivers).
+    *   `other/`: Contains drivers for various I2C-connected audio chips.
+
+*   **`soc/` (Sound Open Firmware & System on Chip)**: This is a very significant and growing area for embedded systems and modern integrated audio.
+    *   `codecs/`: Drivers for audio codecs (ADC/DAC chips) commonly found on SoCs. This is a very large subdirectory with drivers for chips from many vendors (e.g., Realtek, Wolfson Microelectronics/Cirrus Logic, Texas Instruments, Analog Devices).
+    *   `fsl/`, `atmel/`, `imx/`, `rockchip/`, `samsung/`, `mediatek/`, `qcom/`, etc.: Platform-specific ASoC (ALSA System on Chip) drivers that describe how codecs are connected to CPU audio interfaces (like I2S, AC97) on specific SoCs.
+    *   `sof/`: Sound Open Firmware. A framework and firmware for offloading audio processing to DSPs, common in modern Intel and AMD platforms.
+    *   `soc-*.c`: Core ASoC infrastructure files that manage cards, components, DAIs (Digital Audio Interfaces), DAPM (Dynamic Audio Power Management).
+
+*   **`firewire/`**: Drivers for FireWire (IEEE 1394) audio devices.
+    *   Subdirectories for specific FireWire audio interfaces like `bebob/`, `dice/`, `digi00x/`, `fireface/`, `motu/`.
+
+*   **`sparc/`, `ppc/`, `arm/`, `mips/`, `sh/`, `x86/`**: Older, architecture-specific sound drivers or support code, much of which is now superseded by ASoC or more generic drivers.
+
+*   **`synth/`**: Synthesizer-related code, particularly for E-mu wavetable synthesis.
+    *   `emux/`: E-mu SoundFont support.
+
+*   **`virtio/`**: VirtIO sound driver for virtualized environments.
+*   **`xen/`**: Xen paravirtualized sound frontend driver.
+
+## Use for Linux OS
+
+The `sound/` directory and ALSA provide the complete audio stack within the Linux kernel:
+
+*   **Audio Playback and Recording**: Enables applications to play sounds and record audio from microphones or line-in.
+*   **Hardware Support**: Offers drivers for a vast range of internal sound cards, onboard audio chips, USB audio devices, Bluetooth audio, FireWire audio interfaces, and integrated SoC audio solutions.
+*   **Mixer Control**: Allows users and applications to control volume levels, mute/unmute channels, and select input/output sources.
+*   **MIDI Interface**: Provides support for MIDI keyboards, synthesizers, and other MIDI devices, enabling music creation and performance.
+*   **Low-Latency Audio**: Aims to provide low-latency audio paths, which are important for professional audio work and real-time applications.
+*   **Power Management**: ASoC's DAPM helps in dynamically managing power for audio components on embedded devices to save battery life.
+*   **System Sounds**: Enables system event sounds and notifications.
+
+User-space sound servers like PipeWire, PulseAudio, and JACK often sit on top of ALSA, providing higher-level abstractions, mixing capabilities for multiple applications, and easier audio routing for users. However, ALSA remains the fundamental kernel layer that communicates directly with the audio hardware.

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,0 +1,94 @@
+# tools Directory
+
+The `tools/` directory in the Linux kernel source tree contains a collection of user-space tools and utilities that are related to kernel development, testing, debugging, and performance analysis. These tools are compiled and run in user space but often interact closely with kernel features or are used to manage or analyze kernel behavior.
+
+## Purpose
+
+The primary purposes of the `tools/` directory are:
+
+1.  **Kernel Performance Analysis**: Provide tools like `perf` for profiling, tracing, and analyzing kernel and application performance.
+2.  **Kernel Testing**: Include selftests (`testing/selftests/`) that verify the correctness of various kernel subsystems and APIs.
+3.  **Debugging and Tracing Aids**: Offer utilities to help debug kernel issues or trace kernel events.
+4.  **Interacting with Kernel Subsystems**: Provide user-space counterparts or utilities for specific kernel features (e.g., BPF tools, KVM tools, power management tools).
+5.  **Build and Development Utilities**: Some tools might assist in the kernel build process or provide specific development functionalities (though most core build scripts are in `scripts/`).
+
+## Contents
+
+The `tools/` directory is diverse and contains many subdirectories, each often corresponding to a specific tool or category of tools. Key components include:
+
+*   **`perf/`**: The `perf` tool, a powerful and versatile command-line utility for performance analysis.
+    *   It uses kernel performance counters, tracepoints, kprobes, and uprobes.
+    *   Can be used for profiling CPU usage, analyzing cache misses, tracing system calls, monitoring kernel events, and much more.
+    *   Contains a significant amount of code for parsing event data, symbol resolution, and presenting results.
+
+*   **`testing/selftests/`**: A large collection of self-tests for various kernel subsystems.
+    *   Each subdirectory typically focuses on a specific area (e.g., `bpf/`, `cgroup/`, `drivers/`, `efivarfs/`, `ftrace/`, `ipc/`, `kvm/`, `net/`, `powerpc/`, `timers/`, `vm/`).
+    *   These tests are crucial for regression testing and ensuring kernel changes don't break existing functionality.
+    *   They often use specific kernel APIs or features to verify their behavior.
+
+*   **`bpf/`**: Tools related to BPF (Berkeley Packet Filter).
+    *   `bpftool/`: A command-line utility for inspecting and managing BPF programs and maps.
+    *   `runqslower/`: A BPF-based tool to trace slow scheduler runqueue operations.
+    *   Other example BPF programs and utilities.
+
+*   **`power/`**: Tools related to power management.
+    *   `cpupower/`: A collection of user-space utilities to control CPU frequency scaling, power states (cpuidle), and related parameters. Replaces older tools like `cpufreq-utils`.
+    *   `turbostat/` (under `power/x86/`): A tool for reporting processor topology, frequency, idle power-state statistics, temperature and power on Intel CPUs.
+    *   `x86_energy_perf_policy/` (under `power/x86/`): A tool to set the energy vs. performance policy preference on Intel CPUs.
+    *   `acpi/`: Tools like `acpidump` for dumping ACPI tables.
+
+*   **`hv/`**: Tools for interacting with Microsoft Hyper-V virtualization, typically for Linux guests.
+    *   `hv_kvp_daemon.c`: KVP (Key-Value Pair) daemon for exchanging information with the Hyper-V host.
+    *   `hv_fcopy_daemon.c`: File copy daemon.
+    *   `hv_vss_daemon.c`: Volume Shadow Copy Service daemon.
+
+*   **`kvm/`**: Tools for Kernel-based Virtual Machine (KVM).
+    *   Often contains utilities for testing KVM functionality or simple KVM host tools.
+    *   `kvm_stat/`: A tool to display KVM statistics.
+
+*   **`usb/`**: Tools related to USB.
+    *   `usbip/`: Tools for USB/IP, allowing USB devices to be shared over a network.
+    *   `ffs-test.c`: A test utility for the Function Filesystem (USB gadget).
+
+*   **`spi/`**: SPI (Serial Peripheral Interface) testing utilities.
+    *   `spidev_test.c`: A utility for testing `spidev` devices.
+
+*   **`gpio/`**: GPIO (General Purpose Input/Output) utilities.
+    *   `lsgpio.c`: Lists GPIO chips and lines.
+    *   `gpio-event-mon.c`: Monitors GPIO line events.
+
+*   **`iio/`**: IIO (Industrial I/O) utilities.
+    *   `iio_event_monitor.c`: Monitors IIO events.
+    *   `iio_generic_buffer.c`: A tool to capture data from IIO devices.
+
+*   **`leds/`**: LED control utilities.
+    *   `uledmon.c`: Monitors udev events for LEDs.
+
+*   **`objtool/`**: A tool used during the kernel build process to analyze object files for things like stack frame correctness, ORC (Oops ReWind Callstack) generation for unwinding, and static call validation.
+
+*   **`memory-model/`**: Contains tools (`lkmm.o`, `herd`) and litmus tests for verifying and exploring the Linux kernel memory consistency model.
+
+*   **`cgroup/`**: Tools related to cgroups, e.g., for monitoring or testing.
+
+*   **`vm/`**: Tools related to virtual memory, such as `page-types` for debugging page flags.
+
+*   **`virtio/`**: Tools for testing VirtIO drivers and devices (e.g., `vringh_test`, `virtio_test`).
+
+*   **`wmi/`**: Windows Management Instrumentation tools, e.g., `dell-smbios-example.c`.
+
+*   **`tracing/`**: Contains `rtla/`, a real-time latency analysis tool.
+
+*   **`arch/`**: Some architectures may have architecture-specific tools here.
+
+## Use for Linux OS
+
+The tools in the `tools/` directory serve several important functions for the Linux ecosystem:
+
+*   **Kernel Development and Debugging**: `perf`, `objtool`, tracing helpers, and various debugging utilities are essential for kernel developers to understand behavior, find bugs, and optimize code.
+*   **Kernel Validation**: The selftests are a cornerstone of kernel quality assurance, run by developers and automated testing systems to catch regressions.
+*   **System Administration and Monitoring**: Tools like `cpupower` allow administrators to configure and monitor system behavior. `perf` can also be invaluable for sysadmins diagnosing performance issues.
+*   **Hardware Enablement**: Utilities for specific hardware interfaces (SPI, GPIO, IIO) can be used for testing and interacting with new hardware.
+*   **Understanding Kernel Internals**: Many of these tools provide insights into how specific kernel subsystems work, making them useful for learning and exploration.
+*   **User-Space Interaction**: Some tools provide the user-space components needed to interact with specific kernel features (e.g., `bpftool` for BPF, `usbip` tools for USB/IP).
+
+While not part of the running kernel image itself, the `tools/` directory provides a rich ecosystem of utilities that are deeply intertwined with the kernel's development, testing, and operational lifecycle. Many of these tools are considered standard components for anyone working seriously with the Linux kernel.

--- a/virt/README.md
+++ b/virt/README.md
@@ -1,0 +1,59 @@
+# virt Directory
+
+The `virt/` directory in the Linux kernel source tree contains code related to virtualization technologies, primarily focusing on the Kernel-based Virtual Machine (KVM). KVM allows Linux to act as a Type 1 hypervisor, enabling it to create and run virtual machines (VMs) with near-native performance.
+
+## Purpose
+
+The primary purpose of the `virt/` directory is to:
+
+1.  **Provide the core KVM infrastructure**: Implement the architecture-independent parts of KVM, which manage the lifecycle of VMs, virtual CPUs (vCPUs), and their interaction with the host kernel.
+2.  **Interface with hardware virtualization extensions**: While the architecture-specific parts of KVM that directly use hardware virtualization extensions (like Intel VT-x or AMD-V) reside in `arch/<architecture>/kvm/`, this directory provides the generic framework they plug into.
+3.  **Manage VM memory and I/O**: Handle memory virtualization for guests and facilitate emulated or paravirtualized I/O.
+4.  **Support paravirtualization features**: Include code for paravirtualized devices or interfaces (like VirtIO, though VirtIO drivers themselves are in `drivers/virtio/`) that can improve VM performance.
+
+## Contents
+
+The `virt/` directory is relatively small compared to giants like `drivers/` or `net/`, but its contents are highly specialized and critical for virtualization. The main component is KVM:
+
+*   **`kvm/`**: This is the primary subdirectory and contains the architecture-independent core of KVM.
+    *   **`kvm_main.c`**: Core KVM logic, including:
+        *   Creation and management of VM file descriptors.
+        *   Creation and management of vCPU file descriptors.
+        *   Handling KVM ioctls for VM and vCPU control (e.g., setting memory regions, running vCPUs, injecting interrupts).
+        *   Management of KVM slots (memory regions mapped into the guest).
+        *   Coalesced MMIO (Memory-Mapped I/O) handling.
+        *   Dirty page logging for live migration.
+    *   **`eventfd.c`**: Support for using eventfds to signal events to/from KVM guests (e.g., for I/O notification or interrupt injection).
+    *   **`irqchip.c`**: Management of virtual interrupt controllers (though the specific emulation logic might be architecture-specific or in `drivers/irqchip/`).
+    *   **`vfio.c`**: Integration with VFIO (Virtual Function I/O) for assigning physical devices directly to guests (PCI passthrough).
+    *   **`async_pf.c`**: Asynchronous page fault handling for guests.
+    *   **`coalesced_mmio.c`**: Implements coalesced MMIO, a technique to batch MMIO accesses from the guest to reduce VM exit overhead.
+    *   **`binary_stats.c`**: Provides a binary interface for KVM statistics.
+    *   **`pfncache.c`**: Guest page fault optimization by caching guest PFNs (Page Frame Numbers).
+    *   **`guest_memfd.c`**: Support for memory backends using memfd_secret for guests.
+    *   **`dirty_ring.c`**: Manages the dirty page ring buffer for tracking guest memory writes.
+
+*   **`lib/`**: Contains library code that might be shared within virtualization components.
+    *   **`irqbypass.c`**: A manager for handling interrupts in a way that can bypass the guest OS for performance, often used with assigned devices.
+
+It's important to note the division of labor:
+
+*   **`virt/kvm/`**: Architecture-independent KVM core.
+*   **`arch/<architecture>/kvm/`**: Architecture-specific KVM code that directly interacts with hardware virtualization extensions (e.g., `arch/x86/kvm/vmx.c` for Intel VT-x, `arch/x86/kvm/svm.c` for AMD-V). This is where guest state is saved/restored, VM exits are handled, and CPU-specific virtualization features are implemented.
+*   **`drivers/kvm/`**: While less common for core KVM logic, this might contain drivers for auxiliary KVM-related hardware or interfaces if they don't fit neatly into the arch-specific model.
+*   **`drivers/virtio/`**: Drivers for VirtIO paravirtualized devices (e.g., `virtio_net`, `virtio_blk`, `virtio_pci`). These allow guests to use efficient, standardized interfaces for I/O rather than fully emulating hardware.
+*   **`drivers/vfio/`**: VFIO framework for secure device assignment to user space, which KVM leverages for PCI passthrough.
+
+## Use for Linux OS
+
+The code in the `virt/` directory, primarily KVM, transforms Linux into a powerful hypervisor:
+
+*   **Server Virtualization**: Enables running multiple isolated server instances (VMs) on a single physical machine, improving resource utilization and flexibility. This is a cornerstone of cloud computing.
+*   **Desktop Virtualization**: Allows users to run different operating systems (e.g., Windows, other Linux distributions) as guests on their Linux desktop.
+*   **Development and Testing**: Provides isolated environments for software development, testing, and debugging without affecting the host system.
+*   **Security Sandboxing**: VMs can be used to run untrusted applications in a more strongly isolated environment than traditional process-based sandboxes.
+*   **Legacy Application Support**: Allows running older operating systems or applications that are not compatible with the current host environment.
+*   **Near-Native Performance**: By leveraging hardware virtualization extensions, KVM can run guests with very little performance overhead for most workloads.
+*   **Integration with User-Space Tools**: KVM is typically managed by user-space tools like QEMU, libvirt, and cloud orchestration platforms (e.g., OpenStack, Kubernetes via Kubevirt), which use the KVM API (ioctl interface on `/dev/kvm`) to create and control VMs.
+
+KVM, with its core in `virt/kvm/` and its architecture-specific counterparts, is a critical component for modern Linux systems, enabling a wide range of virtualization use cases. Its integration into the mainline kernel means it benefits from the kernel's stability, performance, and feature development.


### PR DESCRIPTION
This commit introduces README.md files for several top-level directories in the kernel source tree.

Each README provides a brief explanation of the directory's purpose and an overview of its typical contents within the context of the Linux OS.

The directories covered are:
- arch
- drivers
- fs
- include
- init
- ipc
- kernel
- lib
- mm
- net
- scripts
- security
- sound
- tools
- virt